### PR TITLE
tests: remove Node.js 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "8"
-  - "9"
   - "10"
 install:
   - npm install 


### PR DESCRIPTION
Node.js 9 and other odd releases are no stable or LTS releases and live for a very short time.

And it also reached its EOL.

https://github.com/nodejs/Release/blob/master/README.md