### PR TITLE
025/support running npm scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ coverage
 
 package-lock.json
 
-
 # local files
 sandbox
 NOTES.md

--- a/bin/drome.js
+++ b/bin/drome.js
@@ -12,6 +12,7 @@ const completion = require('../lib/completion');
 let config;
 let homeConfig = () => { return { tasks: {} }; };
 let projectConfig = () => { return { tasks: {} }; };
+let packageConfig = () => { return { tasks: {} }; };
 
 let homeConfigPath = path.join(homedir, 'drome.config.js');
 
@@ -34,16 +35,23 @@ if (fs.existsSync(projectConfigPath)) {
     console.log(msg);
 }
 
+let packageConfigPath = path.join(path.resolve('./'), 'package.json');
+if (fs.existsSync(packageConfigPath)) {
+    const packageScripts = require(packageConfigPath).scripts;
+    packageConfig = () => { return { tasks: packageScripts }; };
+}
+
+
 config = () => {
     return {
-        tasks: Object.assign(homeConfig().tasks, projectConfig().tasks)
+        tasks: Object.assign(homeConfig().tasks, projectConfig().tasks, packageConfig().tasks)
     };
 };
 
 const { cmd, task, rest } = args(process.argv);
 
-if(cmd == 'completion') {
-    completion.print({cmd, task, rest, config : config(rest)});
+if (cmd == 'completion') {
+    completion.print({ cmd, task, rest, config: config(rest) });
 } else {
     drome(() => config(rest), cmd, task, rest);
 }

--- a/lib/cliUtils.js
+++ b/lib/cliUtils.js
@@ -10,6 +10,7 @@ const hasOption = (options = [], needles = []) => {
 
 const showHelp = () => {
     let taskList = Object.keys(getTaskList());
+
     const tasks = wordwrap(taskList.join(', '), 60, '\n   ');
     const dromeInfo = colors.cyan(`${pkgInfo.name} v${pkgInfo.version}`);
     const help = `

--- a/lib/drome.js
+++ b/lib/drome.js
@@ -4,6 +4,7 @@ const { hasOption } = require('./cliUtils');
 const { getObjectFromPath } = require('./utils');
 
 const drome = (config, cmd = '', start = '', cliOptions) => {
+
     let conf = config();
 
     let silent = hasOption(cliOptions, ['--silent', '-s', '-S', 'silent']);
@@ -24,7 +25,6 @@ const drome = (config, cmd = '', start = '', cliOptions) => {
     let result = run(cmd, startPoint, start, cliOptions).then(() => {
         !silent && logger.footer('==> ending process');
     });
-
     return result;
 };
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -24,6 +24,7 @@ const run = async (cliCommandName, task, name, cliOptions = [], prev) => {
         return await cliCommand(cmd);
     }
     const silent = hasOption(cliOptions, ['--silent', '-s', '-S', 'silent']);
+
     if (typeof task != 'undefined') {
         !silent && logger.info(`Start ${name}`);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,13 @@ const getTaskList = () => {
         projectConfig = require(projectConfigPath);
     }
 
-    return Object.assign(homeConfig().tasks, projectConfig().tasks);
+    let packageConfig = { scripts: {} };
+    const packageFilename = path.join(path.resolve('./'), 'package.json');
+    if (fs.existsSync(packageFilename)) {
+        packageConfig = require(packageFilename);
+    }
+
+    return Object.assign(homeConfig().tasks, projectConfig().tasks, packageConfig.scripts);
 };
 
 const wordwrap = (str, maxChars, lineEnd = '\n') => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ const sanitizeCommand = command => {
                 '.bin',
                 command
             );
-        } catch(e) {
+        } catch (e) {
             return command;
         }
     } else {
@@ -131,7 +131,7 @@ const formatDate = (date = '', useAMPM = true) => {
     let minutes = date.getMinutes();
     let seconds = date.getSeconds();
     let ampm = '';
-    
+
     hours = hours ? hours : 12; // the hour '0' should be '12'
     minutes = minutes < 10 ? '0' + minutes : minutes;
     seconds = seconds < 10 ? '0' + seconds : seconds;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drome",
-  "version": "0.4.1",
+  "version": "0.5.0-alpha.4",
   "description": "Zero-dependencies task runner",
   "main": "lib/drome.js",
   "bin": "bin/drome.js",


### PR DESCRIPTION
Initial implementation of running `npm scripts` from drome.  It uses the same construct as normal drome tasks

```
drome run <nmpScript>
```

When executing `drome help` it will show all defined npm scripts along with drome tasks (both global and project)

![image](https://user-images.githubusercontent.com/183153/46882839-fa570c80-ce04-11e8-8500-6a36e262061d.png)

